### PR TITLE
Use miso from github

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "miso"]
-	path = miso
-	url = git@github.com:dmjio/miso.git

--- a/README.md
+++ b/README.md
@@ -11,14 +11,7 @@ Web app for typical Haskeller answers to everything.
 
 To build the app you should have `nix` installed.
 
-To ease the process of building, it uses `miso` as a GitHub submodule. So, first
-you would need to run:
-
-```
-$ git submodule update --init --recursive
-```
-
-After this is up-to-date, you can run
+After cloning this repo, you can run
 
 ```
 $ nix-build

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,8 @@
 {}:
-with (import ./miso {});
+with (import (builtins.fetchTarball {
+  url = "https://github.com/dmjio/miso/archive/1114ba461605cef11ef4e1a96b5adfc4b4c9af18.tar.gz";
+  sha256 = "03x323yjpx3wq87kb2i202cw6sxj3sb79j4h712jiv4yd993gjlz";
+}) {});
 let
   inherit (pkgs) runCommand closurecompiler;
   inherit (pkgs.haskell.packages) ghcjs86;


### PR DESCRIPTION
This PR removes `miso` as git submodule and uses it directly from GitHub. The idea is to use the builtin function `fetchTarball` and import the result of this function instead of importing local path. To fetch tarball I used the same hash as it was previously with submodule.